### PR TITLE
Remove variation selectors for 🈶(U+1F236)

### DIFF
--- a/emoji_suggestion.yaml
+++ b/emoji_suggestion.yaml
@@ -4,7 +4,7 @@ patch:
   switches/@next:
     name: emoji_suggestion
     reset: 1
-    states: [ "🈚︎", "🈶️" ]
+    states: [ "🈚︎", "🈶" ]
   'engine/filters/@before 0':
     simplifier@emoji_suggestion
   emoji_suggestion:


### PR DESCRIPTION
Per Unicode 16.0, there is no valid emoji variation sequence for U+1F236.

See https://www.unicode.org/Public/16.0.0/ucd/emoji/emoji-variation-sequences.txt